### PR TITLE
Added access to EmailDomain on LogonResponse event

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -116,7 +116,8 @@ func (a *Auth) handleLogOnResponse(packet *Packet) {
 		// some error on Steam's side, we'll get an EOF later
 	} else {
 		a.client.Emit(&LogOnFailedEvent{
-			Result: EResult(body.GetEresult()),
+			Result:      EResult(body.GetEresult()),
+			EmailDomain: body.GetEmailDomain(),
 		})
 		a.client.Disconnect()
 	}

--- a/auth_events.go
+++ b/auth_events.go
@@ -27,7 +27,8 @@ type LoggedOnEvent struct {
 }
 
 type LogOnFailedEvent struct {
-	Result EResult
+	Result      EResult
+	EmailDomain string
 }
 
 type LoginKeyEvent struct {


### PR DESCRIPTION
Earlier, you did not have access to the Steam client's email domain (@gmail.com) for where the auth code was sent to. Now you do.